### PR TITLE
Skip memory deallocation ga

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
     - gcc
 before_install:
     - wget https://raw.githubusercontent.com/yast/yast-devtools/SLE-12-GA/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "yast2-devtools yast2-testsuite doxygen yast2-core-dev libxml2-dev"
+    - sh ./travis_setup.sh -p "yast2-devtools yast2-testsuite doxygen yast2-core-dev libxml2-dev gettext"
 script:
     - make -f Makefile.cvs
     - make

--- a/package/yast2-xml.changes
+++ b/package/yast2-xml.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 19 09:35:03 UTC 2017 - mvidner@suse.com
+
+- Omit libxml2 memory cleanup to prevent a crash (bsc#1047449).
+- 3.1.2
+
+-------------------------------------------------------------------
 Wed Nov 13 15:56:18 UTC 2013 - jreidinger@suse.com
 
 - Add explicit COPYING file

--- a/package/yast2-xml.spec
+++ b/package/yast2-xml.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-xml
 #
-# Copyright (c) 2013 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -23,14 +23,22 @@ Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
 
-Group:	        System/YaST
-License:        GPL-2.0+
-BuildRequires:	gcc-c++ libtool doxygen yast2-core-devel libxml2-devel
+BuildRequires:  doxygen
+BuildRequires:  gcc-c++
+BuildRequires:  libtool
+BuildRequires:  libxml2-devel
+BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-devtools >= 3.1.10
-Summary:	YaST2 - XML Agent
-Requires:	yast2-core
-Provides:	yast2-agent-xml yast2-agent-xml-devel yast2-lib-xml
-Obsoletes:	yast2-agent-xml yast2-agent-xml-devel yast2-lib-xml
+Summary:        YaST2 - XML Agent
+License:        GPL-2.0+
+Group:          System/YaST
+Requires:       yast2-core
+Provides:       yast2-agent-xml
+Provides:       yast2-agent-xml-devel
+Provides:       yast2-lib-xml
+Obsoletes:      yast2-agent-xml
+Obsoletes:      yast2-agent-xml-devel
+Obsoletes:      yast2-lib-xml
 
 %description
 The YaST2 XML agent
@@ -46,10 +54,11 @@ The YaST2 XML agent
 
 rm -f $RPM_BUILD_ROOT/%{yast_plugindir}/libpy2ag_xml.la
 
-
 %files
 %defattr(-,root,root)
 %{yast_plugindir}/libpy2ag_xml.so.*
 %{yast_plugindir}/libpy2ag_xml.so
 %{yast_scrconfdir}/xml.scr
 %doc %{yast_docdir}
+
+%changelog

--- a/package/yast2-xml.spec
+++ b/package/yast2-xml.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-xml
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/XmlAgent.cc
+++ b/src/XmlAgent.cc
@@ -30,7 +30,8 @@ XmlAgent::XmlAgent() : SCRAgent()
  */
 XmlAgent::~XmlAgent()
 {
-    xmlCleanupParser ();
+    // bsc#1047449, this crashes if ruby uses nokogiri (which also uses libxml2)
+    // xmlCleanupParser ();
 }
 
 


### PR DESCRIPTION
[bsc#1047449](https://bugzilla.suse.com/show_bug.cgi?id=1047449)
https://trello.com/c/f51Q25dC

This is a redo of #4, because of how SLE branching works in the internal OBS:

https://build.suse.de/request/show/136105
> Request got declined
yast2-xml was never forked, please submit to SUSE:SLE-12:Update instead

