### PR TITLE
SLE12-SP5 Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/SLE-12-GA/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "yast2-devtools yast2-testsuite doxygen yast2-core-dev libxml2-dev gettext"
-script:
-    - make -f Makefile.cvs
-    - make
-    - make check
-    - sudo make install
+sudo: required
+language: bash
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-xml-image .
+script:
+  # the "yast-travis-cpp" script is included in the base yastdevel/cpp image
+  # see https://github.com/yast/docker-yast-cpp/blob/master/yast-travis-cpp
+  - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-xml-image yast-travis-cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM yastdevel/cpp:sle12-sp5
+
+RUN zypper --non-interactive in --no-recommends \
+  libxml2-devel
+COPY . /usr/src/app


### PR DESCRIPTION
- Fix the Travis build failure, for some reason it still used the old Ubuntu based builds
- Ported to the usual Docker based builds as everywhere