### PR TITLE
Fix agent string output

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://EditorConfig.org  -*- ini -*-
+# This is a unified way to tell all your editors
+# about the proper indentation style in this repo.
+#
+# Emacs:   https://github.com/editorconfig/editorconfig-emacs#readme
+# Vim:     https://github.com/editorconfig/editorconfig-vim#readme
+# VS Code: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+
+# don't continue looking in upper directories, this is the top level
+root = true
+
+[*.{h,cc}]
+indent_style = tab
+indent_size = 4
+tab_width = 8

--- a/package/yast2-xml.changes
+++ b/package/yast2-xml.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 16 13:36:00 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Return string instead of Boolean when calling Execute with
+  .xml.string (bsc#1153539)
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Feb 26 14:17:57 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Version bump (bsc#1124009)

--- a/package/yast2-xml.spec
+++ b/package/yast2-xml.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-xml
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/XmlAgent.cc
+++ b/src/XmlAgent.cc
@@ -932,7 +932,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     xmlIndentTreeOutput  = 1;
     xmlKeepBlanksDefault	(0);
 
-    if (!strcmp(input,"string"))
+    if (strcmp(input,"string"))
     {
 	xmlDocDumpFormatMemory (newDoc, &mem, &size, 1);
 

--- a/src/XmlAgent.cc
+++ b/src/XmlAgent.cc
@@ -932,7 +932,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     xmlIndentTreeOutput  = 1;
     xmlKeepBlanksDefault	(0);
 
-    if (strcmp(input,"string"))
+    if (path->component_str (0) == "string")
     {
 	xmlDocDumpFormatMemory (newDoc, &mem, &size, 1);
 

--- a/src/XmlAgent.cc
+++ b/src/XmlAgent.cc
@@ -850,7 +850,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
 
     YCPValue result = YCPVoid();
     int size;
-    std::string pth;
+    bool string_output = false;
 
     xmlDocPtr doc, newDoc;
     xmlChar *mem;
@@ -858,7 +858,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     for (int i=0; i<path->length(); i++)
     {
         if (path->component_str (i) == "string")
-            pth = path->component_str (i);
+            string_output = true;
     }
 
     YCPMap argMap = arg->asMap();
@@ -867,7 +867,6 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     Cdata = getMapValueAsList ( options,"cdataSections" );
     ListEntries = getMapValueAsMap(options,"listEntries");
 
-    const bool string_output = (pth == "string");
     const char *rootElement	= getMapValue ( options,"rootElement");
     const char *systemID	= getMapValue ( options,"systemID" );
     const char *typeNS		= getMapValue ( options,"typeNamespace" );

--- a/src/XmlAgent.cc
+++ b/src/XmlAgent.cc
@@ -850,7 +850,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
 
     YCPValue result = YCPVoid();
     int size;
-    std::string input;
+    std::string pth;
 
     xmlDocPtr doc, newDoc;
     xmlChar *mem;
@@ -858,7 +858,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     for (int i=0; i<path->length(); i++)
     {
         if (path->component_str (i) == "string")
-            input = path->component_str (i);
+            pth = path->component_str (i);
     }
 
     YCPMap argMap = arg->asMap();
@@ -867,6 +867,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     Cdata = getMapValueAsList ( options,"cdataSections" );
     ListEntries = getMapValueAsMap(options,"listEntries");
 
+    const bool string_output = (pth == "string");
     const char *rootElement	= getMapValue ( options,"rootElement");
     const char *systemID	= getMapValue ( options,"systemID" );
     const char *typeNS		= getMapValue ( options,"typeNamespace" );
@@ -879,7 +880,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     {
         filename =  fileName;
     }
-    else if (input == "string")
+    else if (string_output)
     {
         y2milestone("String handling");
     }
@@ -919,7 +920,7 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     xmlIndentTreeOutput  = 1;
     xmlKeepBlanksDefault (0);
 
-    if (input == "string")
+    if (string_output)
     {
         xmlDocDumpFormatMemory (newDoc, &mem, &size, 1);
 

--- a/src/XmlAgent.cc
+++ b/src/XmlAgent.cc
@@ -850,21 +850,15 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
 
     YCPValue result = YCPVoid();
     int size;
-    const char * input = "";
-    const char *content = "";
+    std::string input;
 
     xmlDocPtr doc, newDoc;
     xmlChar *mem;
 
     for (int i=0; i<path->length(); i++)
     {
-	if (path->component_str (i)=="xmlrpc")
-	{
-	    content = (const char *)path->component_str (i).c_str();
-	}
-	else if (path->component_str (i) == "string") {
-	    input = (const char *)path->component_str (i).c_str();
-	}
+        if (path->component_str (i) == "string")
+            input = path->component_str (i);
     }
 
     YCPMap argMap = arg->asMap();
@@ -885,9 +879,9 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
     {
         filename =  fileName;
     }
-    else if (input && *input)
+    else if (input == "string")
     {
-	y2milestone("String handling");
+        y2milestone("String handling");
     }
     else
     {
@@ -898,56 +892,47 @@ YCPValue XmlAgent::Execute(const YCPPath &path, const YCPValue& value, const YCP
 
     doc = xmlNewDoc((const xmlChar *)"1.0");
 
-    if (!strcmp(content,"xmlrpc"))
+    xmlNodePtr root = xmlNewDocNode(doc, NULL, (const xmlChar *)rootElement, NULL);
+    xmlDocSetRootElement (doc, root);
+
+    if (nameSpace && *nameSpace)
     {
-	y2milestone("XML-RPC handling");
-	doc->children = xmlNewDocNode(doc, NULL, (const xmlChar *)"methodCall", NULL);
-	newDoc =  ParseYCPMethodCall(argMap, doc);
+        xmlNewNs (root,  (const xmlChar *)nameSpace, NULL);
     }
-    else
-    {
-	xmlNodePtr root = xmlNewDocNode(doc, NULL, (const xmlChar *)rootElement, NULL);
-	xmlDocSetRootElement (doc, root);
 
-	if (nameSpace && *nameSpace)
-	{
-	xmlNewNs (root,  (const xmlChar *)nameSpace, NULL);
-	}
-
-	if (typeNS && *typeNS) {
-	configNamespace = xmlNewNs (root,  (const xmlChar *)typeNS, (const xmlChar *)"config");
-	}
-	else {
-	    configNamespace = NULL;
-	}
-
-
-	doc->children = ParseYCPMap(argMap, root, doc);
-	doc->intSubset = xmlCreateIntSubset (doc,
-					     (const xmlChar *)rootElement,
-					     NULL,
-					     (const xmlChar *)( strlen(systemID)>0 ? systemID : NULL ));
-	newDoc = xmlCopyDoc (doc,1);
+    if (typeNS && *typeNS) {
+        configNamespace = xmlNewNs (root,  (const xmlChar *)typeNS, (const xmlChar *)"config");
     }
+    else {
+        configNamespace = NULL;
+    }
+
+
+    doc->children = ParseYCPMap(argMap, root, doc);
+    doc->intSubset = xmlCreateIntSubset (doc,
+                                        (const xmlChar *)rootElement,
+                                        NULL,
+                                        (const xmlChar *)( strlen(systemID)>0 ? systemID : NULL ));
+
+    newDoc = xmlCopyDoc (doc,1);
+
     xmlIndentTreeOutput  = 1;
-    xmlKeepBlanksDefault	(0);
+    xmlKeepBlanksDefault (0);
 
-    if (path->component_str (0) == "string")
+    if (input == "string")
     {
-	xmlDocDumpFormatMemory (newDoc, &mem, &size, 1);
+        xmlDocDumpFormatMemory (newDoc, &mem, &size, 1);
 
-	result = YCPString((const char *)mem);
+        result = YCPString((const char *)mem);
 
-	xmlFree(mem);
+        xmlFree(mem);
+        xmlFreeDoc(doc);
     }
     else
     {
-	result = YCPBoolean( xmlSaveFormatFile(filename, newDoc, 1) != -1 );
-    }
-    xmlFreeDoc(doc);
-    if (strcmp(input,"string"))
-    {
-	xmlFreeDoc(newDoc);
+        result = YCPBoolean( xmlSaveFormatFile(filename, newDoc, 1) != -1 );
+        xmlFreeDoc(doc);
+        xmlFreeDoc(newDoc);
     }
     return result;
 }


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1153539

Calling Execute with .xml.string ... return a Boolean instead of a string. 

This PR tries to fix that for showing the profile source in the AutoYaST dialog

![Screenshot from 2019-10-16 14-46-55](https://user-images.githubusercontent.com/7056681/66925208-e94a6800-f023-11e9-87bb-edc9d257b943.png)
